### PR TITLE
Make Quartz config parameter editable as Quarkus config parameter

### DIFF
--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzBuildTimeConfig.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzBuildTimeConfig.java
@@ -58,6 +58,16 @@ public class QuartzBuildTimeConfig {
     public String tablePrefix;
 
     /**
+     * The SQL string that selects a row in the "LOCKS" table and places a lock on the row.
+     * <p>
+     * If not set, the default value applies, for which the "{0}" is replaced during run-time with the `table-prefix`,
+     * the "{1}" with the `instance-name`.
+     * </p>
+     */
+    @ConfigItem(defaultValue = "SELECT * FROM {0}LOCKS WHERE SCHED_NAME = {1} AND LOCK_NAME = ? FOR UPDATE")
+    public String selectWithLockSql;
+
+    /**
      * Trigger listeners.
      */
     @ConfigItem

--- a/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzScheduler.java
+++ b/extensions/quartz/runtime/src/main/java/io/quarkus/quartz/runtime/QuartzScheduler.java
@@ -523,6 +523,8 @@ public class QuartzScheduler implements Scheduler {
                 props.put(StdSchedulerFactory.PROP_JOB_STORE_PREFIX + ".acquireTriggersWithinLock", "true");
                 props.put(StdSchedulerFactory.PROP_JOB_STORE_PREFIX + ".clusterCheckinInterval",
                         "" + quartzSupport.getBuildTimeConfig().clusterCheckinInterval);
+                props.put(StdSchedulerFactory.PROP_JOB_STORE_PREFIX + ".selectWithLockSQL",
+                        buildTimeConfig.selectWithLockSql);
             }
 
             if (buildTimeConfig.storeType.isNonManagedTxJobStore()) {


### PR DESCRIPTION
In order to modify the Quartz parameter org.quartz.jobStore.selectWithLockSQL for our needs, we require an additional parameter in Quarkus.