### PR TITLE
Use hibernate-processor instead of the hibernate-jpamodelgen

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -5492,6 +5492,11 @@
             </dependency>
             <dependency>
                 <groupId>org.hibernate.orm</groupId>
+                <artifactId>hibernate-processor</artifactId>
+                <version>${hibernate-orm.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.orm</groupId>
                 <artifactId>hibernate-jpamodelgen</artifactId>
                 <version>${hibernate-orm.version}</version>
             </dependency>

--- a/docs/src/main/asciidoc/hibernate-orm.adoc
+++ b/docs/src/main/asciidoc/hibernate-orm.adoc
@@ -1695,8 +1695,8 @@ section of the Hibernate Validator guide for more details.
 == Static metamodel and Jakarta Data
 
 Both static metamodel and Jakarta Data capabilities of Hibernate ORM are available in Quarkus
-through the `hibernate-jpamodelgen` annotation processor. Since it is an annotation processor,
-you must configure the annotation processor in your build tool:
+through the `hibernate-processor` annotation processor. Since it is an annotation processor,
+you must configure it accordingly in your build tool:
 
 [source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
 .pom.xml
@@ -1707,11 +1707,14 @@ you must configure the annotation processor in your build tool:
         <annotationProcessorPaths>
             <path>
                 <groupId>org.hibernate.orm</groupId>
-                <artifactId>hibernate-jpamodelgen</artifactId>
+                <artifactId>hibernate-processor</artifactId>
                 <!-- Note, no artifact version is required, it's managed by Quarkus.  -->
             </path>
             <!-- other processors that may be required by your app -->
         </annotationProcessorPaths>
+        <annotationProcessors>
+            <annotationProcessor>org.hibernate.processor.HibernateProcessor</annotationProcessor>
+        </annotationProcessors>
         <!-- Other compiler plugin configuration options -->
     </configuration>
 </plugin>
@@ -1721,9 +1724,9 @@ you must configure the annotation processor in your build tool:
 .build.gradle
 ----
 // Enforce the version management of your annotation processor dependencies,
-// so that there's no need to define an explicit version of the hibernate-jpamodelgen
+// so that there's no need to define an explicit version of the hibernate-processor
 annotationProcessor enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
-annotationProcessor 'org.hibernate.orm:hibernate-jpamodelgen'
+annotationProcessor 'org.hibernate.orm:hibernate-processor'
 ----
 
 === Static metamodel
@@ -1760,7 +1763,7 @@ For a more detailed overview of static metamodel, please refer to the link:{jaka
 
 === Jakarta Data
 
-Jakarta Data requires, besides having the `hibernate-jpamodelgen` annotation processor in place, one extra dependency to be added:
+Jakarta Data requires, besides having the `hibernate-processor` annotation processor in place, one extra dependency to be added:
 
 [source,xml,role="primary asciidoc-tabs-target-sync-cli asciidoc-tabs-target-sync-maven"]
 .pom.xml

--- a/extensions/panache/hibernate-orm-panache-kotlin/runtime/pom.xml
+++ b/extensions/panache/hibernate-orm-panache-kotlin/runtime/pom.xml
@@ -109,12 +109,12 @@
                             <annotationProcessorPaths>
                                 <annotationProcessorPath>
                                     <groupId>org.hibernate.orm</groupId>
-                                    <artifactId>hibernate-jpamodelgen</artifactId>
+                                    <artifactId>hibernate-processor</artifactId>
                                     <version>${hibernate-orm.version}</version>
                                 </annotationProcessorPath>
                             </annotationProcessorPaths>
                             <annotationProcessors>
-                                <annotationProcessor>org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor</annotationProcessor>
+                                <annotationProcessor>org.hibernate.processor.HibernateProcessor</annotationProcessor>
                             </annotationProcessors>
                         </configuration>
                     </execution>

--- a/extensions/panache/hibernate-orm-panache/runtime/pom.xml
+++ b/extensions/panache/hibernate-orm-panache/runtime/pom.xml
@@ -58,11 +58,11 @@
                     <annotationProcessorPaths>
                         <annotationProcessorPath>
                             <groupId>org.hibernate.orm</groupId>
-                            <artifactId>hibernate-jpamodelgen</artifactId>
+                            <artifactId>hibernate-processor</artifactId>
                         </annotationProcessorPath>
                     </annotationProcessorPaths>
                     <annotationProcessors>
-                        <annotationProcessor>org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor</annotationProcessor>
+                        <annotationProcessor>org.hibernate.processor.HibernateProcessor</annotationProcessor>
                     </annotationProcessors>
                 </configuration>
             </plugin>

--- a/extensions/panache/hibernate-reactive-panache-kotlin/runtime/pom.xml
+++ b/extensions/panache/hibernate-reactive-panache-kotlin/runtime/pom.xml
@@ -118,12 +118,12 @@
                             <annotationProcessorPaths>
                                 <annotationProcessorPath>
                                     <groupId>org.hibernate.orm</groupId>
-                                    <artifactId>hibernate-jpamodelgen</artifactId>
+                                    <artifactId>hibernate-processor</artifactId>
                                     <version>${hibernate-orm.version}</version>
                                 </annotationProcessorPath>
                             </annotationProcessorPaths>
                             <annotationProcessors>
-                                <annotationProcessor>org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor</annotationProcessor>
+                                <annotationProcessor>org.hibernate.processor.HibernateProcessor</annotationProcessor>
                             </annotationProcessors>
                         </configuration>
                     </execution>

--- a/extensions/panache/hibernate-reactive-panache/runtime/pom.xml
+++ b/extensions/panache/hibernate-reactive-panache/runtime/pom.xml
@@ -62,11 +62,11 @@
                     <annotationProcessorPaths>
                         <annotationProcessorPath>
                             <groupId>org.hibernate.orm</groupId>
-                            <artifactId>hibernate-jpamodelgen</artifactId>
+                            <artifactId>hibernate-processor</artifactId>
                         </annotationProcessorPath>
                     </annotationProcessorPaths>
                     <annotationProcessors>
-                        <annotationProcessor>org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor</annotationProcessor>
+                        <annotationProcessor>org.hibernate.processor.HibernateProcessor</annotationProcessor>
                     </annotationProcessors>
                 </configuration>
             </plugin>

--- a/integration-tests/gradle/src/main/resources/compile-only-lombok/build.gradle
+++ b/integration-tests/gradle/src/main/resources/compile-only-lombok/build.gradle
@@ -22,9 +22,9 @@ dependencies {
     testCompileOnly "org.projectlombok:lombok:${lombokVersion}"
     testAnnotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 
-    compileOnly "org.hibernate.orm:hibernate-jpamodelgen"
+    compileOnly "org.hibernate.orm:hibernate-processor"
     compileOnly enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
-    annotationProcessor "org.hibernate.orm:hibernate-jpamodelgen"
+    annotationProcessor "org.hibernate.orm:hibernate-processor"
     annotationProcessor enforcedPlatform("${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}")
 
     testImplementation 'io.quarkus:quarkus-junit5'

--- a/integration-tests/hibernate-orm-data/pom.xml
+++ b/integration-tests/hibernate-orm-data/pom.xml
@@ -136,9 +136,12 @@
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.hibernate.orm</groupId>
-                            <artifactId>hibernate-jpamodelgen</artifactId>
+                            <artifactId>hibernate-processor</artifactId>
                         </path>
                     </annotationProcessorPaths>
+                    <annotationProcessors>
+                        <annotationProcessor>org.hibernate.processor.HibernateProcessor</annotationProcessor>
+                    </annotationProcessors>
                 </configuration>
             </plugin>
         </plugins>

--- a/integration-tests/hibernate-orm-jpamodelgen/pom.xml
+++ b/integration-tests/hibernate-orm-jpamodelgen/pom.xml
@@ -149,9 +149,12 @@
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.hibernate.orm</groupId>
-                            <artifactId>hibernate-jpamodelgen</artifactId>
+                            <artifactId>hibernate-processor</artifactId>
                         </path>
                     </annotationProcessorPaths>
+                    <annotationProcessors>
+                        <annotationProcessor>org.hibernate.processor.HibernateProcessor</annotationProcessor>
+                    </annotationProcessors>
                 </configuration>
             </plugin>
         </plugins>

--- a/integration-tests/maven/src/test/resources-filtered/projects/apt-in-annotation-processor-paths/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/apt-in-annotation-processor-paths/pom.xml
@@ -64,7 +64,7 @@
 		  <annotationProcessorPaths>
 		    <path>
               <groupId>org.hibernate.orm</groupId>
-              <artifactId>hibernate-jpamodelgen</artifactId>
+              <artifactId>hibernate-processor</artifactId>
 		    </path>
 		    <path>
               <groupId>com.querydsl</groupId>

--- a/integration-tests/maven/src/test/resources-filtered/projects/apt-in-annotation-processors/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/apt-in-annotation-processors/pom.xml
@@ -65,7 +65,7 @@
 		  <annotationProcessorPaths>
 		    <path>
               <groupId>org.hibernate.orm</groupId>
-              <artifactId>hibernate-jpamodelgen</artifactId>
+              <artifactId>hibernate-processor</artifactId>
 		    </path>
 		    <path>
               <groupId>com.querydsl</groupId>
@@ -76,7 +76,7 @@
 		  </annotationProcessorPaths>
 		  <!-- Only include the Hibernate one -->
 		  <annotationProcessors>
-			  <annotationProcessor>org.hibernate.jpamodelgen.JPAMetaModelEntityProcessor</annotationProcessor>
+			  <annotationProcessor>org.hibernate.processor.HibernateProcessor</annotationProcessor>
 		  </annotationProcessors>
 		</configuration>
       </plugin>

--- a/integration-tests/maven/src/test/resources-filtered/projects/apt-in-classpath/pom.xml
+++ b/integration-tests/maven/src/test/resources-filtered/projects/apt-in-classpath/pom.xml
@@ -47,7 +47,7 @@
     </dependency>
     <dependency>
       <groupId>org.hibernate.orm</groupId>
-      <artifactId>hibernate-jpamodelgen</artifactId>
+      <artifactId>hibernate-processor</artifactId>
       <scope>provided</scope>
     </dependency>
     <!-- Second APT dep -->


### PR DESCRIPTION
Hey @yrodiere 👋🏻 😄 

I promise it's not a Dependabot PR!!! 🤣 

in 7 that artifact got renamed + processor class renamed as well.

I still see the old one in some openrewrite templates, but I think those are for previous versions of Quarkus, so not yet applicable? 